### PR TITLE
Added Rigid Body System Derivatives and  Rigid Body Problem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(${PROJECT_NAME}
     src/io/write_scene.cpp
     src/io/opt_results.cpp
 
+    src/physics/rigid_body.cpp
     src/physics/rigid_body_system.cpp
     src/physics/mass_matrix.cpp
     src/physics/center_of_mass.cpp
@@ -59,6 +60,7 @@ add_library(${PROJECT_NAME}
     src/opt/optimization_results.cpp
     src/opt/particles_problem.cpp
     src/opt/volume_constraint.cpp
+    src/opt/rigid_body_problem.cpp
 
     src/solvers/barrier_newton_solver.cpp
     src/solvers/ipopt_solver.cpp

--- a/python/rigid_body_transform.ipynb
+++ b/python/rigid_body_transform.ipynb
@@ -1,0 +1,162 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from sympy import *\n",
+    "init_printing()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vertices = np.array(symbols('v_x v_y'))\n",
+    "translation = np.array(symbols('w_x w_y'))\n",
+    "theta = symbols('\\\\theta')\n",
+    "w = [translation[0], translation[1], theta]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "R = np.array([[cos(theta), -sin(theta)], [sin(theta), cos(theta)]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAgMAAAAWBAMAAACvcYJlAAAAMFBMVEX///8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAInZUiRDNmWbvRN27qzJGkhbKAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAFiUlEQVRYCb1YXWgcVRg9s7uz/5ldsEWDPkxjND4oLKJoKOhWYwxCYRWxotYsVIs+mYRQin1Z86Aiha5K8YcallpKQx+SoiIarGtAqQ+lIQgWrbjog7Y+pPaHitTouTN3ZnZmbnaTKXhJMvf7znfOd+6dO5NNABTRedi41rkogEbhBCR8YSQ9uTB58em5gQXGSm6snEg8aypRdTIKR61kZyPpOQs72EnZAu/qVEFM4LGtLdzcpa635hWsleMxwrNr1nNMOFsRbsGMAPWqEnKTFn5Cn0Oy4uaUk9kxN71mjstQTK5VzzWB5xXqbopgquZGyonAE02sIO0tUVmoe9kw54gHrnV2rXquCbwmWypNEMx0sSTw5QYuAvu7VHpwmHOnB0aYRdLzSBl5fpUmCB7uYkngP8L4C3ihS6UHhznK7h6hyyySnkdK1mx9pQmCk3wdDJj4yHGxbehB6BMDDfwydavICfwC4n8DW50S+/rYBHIlmWKt9uKi8dl435LIhDmyuz5Qw2/YLO+KJMtLND3PuT45VMK2vpdh3NZX9ZlILNotlCYI8t4m4nV8II1ob2Om9UcRC3oTOZEjHltB4k/gVVkiL+VBZKS2VZtbRGYJy0UlR3ZPsdMZzDb8SnYURa/deW8pO20cQ958BpjzmUhX7Q5KEwR5+69LVa1ffaIwWcVg8WM+/uf2IyESxPP//PRzHdgsQndopV2Il+0wK2rzi8jXUagxFebI7jew01tIim0Kjkh67c53Iv5mrgxjZaaCMtU9E3GxIxxKEwTfByoZEx/aVRgtA8ZFoFD+csFySjzTxKjJXRElT8yLcZxPB9eSLYkUh6gVW9BEwWQY4OyZn39vfv4LAuxkrCDFWWhE1XOc65couUxDl3JXNwl1z4RxnuFqJgiyErMVmLyIsWzCevALzcdfuiISxLmsfRVgRoTeyF5GzIlErX8LAhx5A9gpVrdPl0N1rxH1HOfGBSrd3wCu6sP/jnHuGc/W7SZKEwR3EN4DHp2+8YeLwCjZ1ikYr+j7WsSIjzbwKWf+BwGpOa7l4CKagCZq27YgzHG67xIn5RxiAxvGqegblp4NrF1POM/egTxPpbhh4hRc2YgnVzj3TAQeBEgTtneCC6w+iXgrVjyTpADfBSi9w4Pxq4meGjHihUZcfCbYy++2wSXfh/Jlo85jI2rbtiDMcbbgJPi4lrGpp7mDj5JvWHoWsC69eCtRqJyl0k76yIwhu8Jepxl7JtJNu1HAhO2doPhVN4wNSGPB4FR7F4ni2Rae46rzRSaI99SebnE2we+2kahqZe2puViTrUUtb29SvgvCHKf7MGYWsw3U8mYLo1W0D6FnA+vS24CNR3E7hfg3xRZjGsnyYAVfMfZMpEy7j9+E9E7wKOHUSI0/xekBtk9ugTa5tZEd6XtExMT1CevUHhNh25h8nbtT7jEBUWt8e+DZUwd+PyXeemGO0z01ecvSCCsKLSD3CSdtQ+hZwHr0hPPvsESm/v1QEdcP/YBDU/0Nxp6JnLiVHAETtneCuZYF8w1wXpMz38XFtTlf3g5yjUwrnA5znO5O7bL4L8XdTtR2tYC22Jp20fsc00EGY5eEGyUaMGF7J5geswt6E1Xrc0BQzMHVf0/lWrNBAuMw54ivSqsP84UgvgJDAoFsN73j2fNBBmPXBHZL1G+CeyS8C1A8Nxzb33jgIXsW+Clx3BTIW2F89zeqdEcOz+zpQ/0V6GaIagOhtONR7QH37K2GKe7CoDVVKN9gwrsF8vNkx+HgX6uqHsUJVbojxyGknUn3a0c9vZivqSQcUr6iQgHLuwVqSr7HkniaD294LGWr4ST3tmZl1RwVoUuuo16PeVhJdxb2ihIFLO+rgatwFOl7+xXJ/zkVnypH6uh4/w9qa+qGRSgRfQAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\left ( v_{x} \\cos{\\left (\\theta \\right )} - v_{y} \\sin{\\left (\\theta \\right )} + w_{x}, \\quad v_{x} \\sin{\\left (\\theta \\right )} + v_{y} \\cos{\\left (\\theta \\right )} + w_{y}\\right )$$"
+      ],
+      "text/plain": [
+       "(vₓ⋅cos(\\theta) - v_y⋅sin(\\theta) + wₓ, vₓ⋅sin(\\theta) + v_y⋅cos(\\theta) + w_y\n",
+       ")"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t = R.dot(vertices) + translation\n",
+    "t[0], t[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def grad(x, w):\n",
+    "    return [diff(x, wi) for wi in w]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmYAAAAXBAMAAABT4570AAAAMFBMVEX///8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAdt0yiUQQq5nNu+9UZiJQkanoAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAGcklEQVRYCc1Zb4gUZRj/7c7u3O3/PRE0qFw0NEhsE/pixY1xZkbaFn0JgxvN0Iy6uyIUIbqL64MfPJboi2W4R6CUqBdSiv3b/tAXCdcgKCOcIKK6ovQ8M7U/z/PO7M77zszNzS37oYfdned93uf3vL/5zfu+M3OHeUtAn05a3i7mHKJWtkQig4LoxBaXoxYKz2uHnISx1VoD0KeTdr1dLFmcS9FYXWQLUACfRGUuxUJy2yEnY4RctmbaUv84idVj/mBwJP+BG88a5M9/FnCGcnvCvM+oM7a2LEAzaNa30PJXWGn6YyGRyOQmG60qAiNxW8OTbA227r7USmk5+7DZajXCneRlt/8JctONzUDKdIOzeXqVMg7rJQEK1ixV11d4y+g795veWGg7Mrn+4VYdxsjcHM0Q82uWKyFRawFncUy3fw+596FQRm7YDc7mddNlpdGmBChYsy+5rM8Wmb5QWCAyOd2twhiZW4hm6UFk/Uq6pWbyJgBtGoU68O5MKf54hkK9FVwToGDNDgKnTR9yjpq1Q44wCrcQzQrDSNI5zNWSVaCrhN4G8Hp07COU+gy0vwUoWDNa/v11X8W5adYOOcYo3EI0GyDN6BwCTV9YxHKnR7uhp/rzcaw88f2CIoW6DWCgiNMVYK2K3TSCeN0J6aN9dWzreQmMptgooJ9HdlqAAjXTWbOGWpFafs1kbtjWdz/0kYUV3HbmOsqORo5y868NareM9Qw5GIVbiGa/G9DO+zjagUR2Asedvu1ACcuA40XtHwql6LwWlfGABXzjZDgH4xQyg44/WU8e01YgXRRoMbtiU0hQAQIFapa/SCukqFakll8zmVv+fWwsr7QwrtcQp+xI5ERufBCZIfRaNkbhNotmxDPQfu2ugp8O2DaaMECbzSGApyVPpaM7dlwl9xP6upav74a4bXNoL7IfxumiTAk0eNKm/9zxwoQAzayZwVjF/JrJ3FJVnLJuIrFvfxcJwkUil+Rc2s3TEyjQBGCMwi1EswEDSe88019ezFY2M0U86nCPX7kRrNlbAKdnKsBJXmjElL5NBHl4G8k6hch0vhi9deCiQAPvELDGa5pBgZoxpJ/6PebXTOZG5wDtGlAwbh23CBmJHDiXNauhQAMyRuEWohndA7I0XLD1m2jy19f9O+zR7DxyfMfdqGKTlxBzImLR85Z3RaCFZsTvnClAgZqB9rPTdbUitRYRxGMSN17MvEkWalv2E16c/6zkwLmqZgq3EM1IZnHmHkZ280XQgrTtRzw1JWmWqkOfRnyYOtW1iW564HMwvKGLeXZZoIF9dOOo4GYbFKwZzWPW1GMBmknc6D5mz7MxUz9Xpr0pCrk857qaEUblJmumq3RyE6Bdy1SDzdZBZMvoGbvXAj4Gnpc0S9OlncYpxp1tZttHovEpHhxEjZp76fpn6MY8JdDAOM2FSpYf6AgkNDPJd43eN78FdtMC9xhrRh/ZJG60n6F+ghb1nUV0NWhfikIuy7muZoxRuMmaDdAAsi3Hk2X9Lzni+uvwA2LWLr4GJM8R3sxetfezxCBpqC/h1BE3n71ENW/AuKRNkD/ZwAbtGFKGQIsnjK7G5jL1EIg18wxMmsXr+jF4OfLa9KRC4kbvwQnrjjJeocuRtohCFHIiN11Dyt7PGKNwczTrOnRhCPGlxFWyLT30or3YlCKu272+gRzGNYo8fGZ+ZdV7B1ZdfePsBSqfLAHb7Ldp7+vh6HfIP16K1Qik7+yz8FPfcwJN7YcoNDJGDggk5pk6MGmmr15Q9nHc9dGyopejxA1bRzcgP7q2klzfw1UjkeNc7dDJx46evOsoPUMxRuHWnGfMFp+LX/Una6ptpTWltJyGmGLs50tORD50GV1Fue348bLjMEhopg5MmtkWmWMgN7RDTsEQN0Uzw+ElHxJyw+Nrf+Q9EW5+3Yzxe7fP4pVMUx65r/U+zyChmTpwSzNDRjm+mmoHg7m1RU45IY9mejGAz6aAmBOaTFSD2PK+IewX56gc4uV+pd1sHHEcBgnN1IGbmkXlOAM3samJkeZATjkhj2a5Jn/5GDRXnP6tX62+R051fL3mOAcCOpHd82ZQGNslkNBMHbipWVSOM3BDO+QUjNDs7iWgTyftN7tYzgoq+jQOB4WRtzVi0Dx6KfBaolP/D2iHnIQhbkH0vHQ72x4Sf1rpbM2OVfufkvtifsfOsPOFIpL7DwV0/KzcXDeXAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\left [ \\left [ 1, \\quad 0, \\quad - v_{x} \\sin{\\left (\\theta \\right )} - v_{y} \\cos{\\left (\\theta \\right )}\\right ], \\quad \\left [ 0, \\quad 1, \\quad v_{x} \\cos{\\left (\\theta \\right )} - v_{y} \\sin{\\left (\\theta \\right )}\\right ]\\right ]$$"
+      ],
+      "text/plain": [
+       "[[1, 0, -vₓ⋅sin(\\theta) - v_y⋅cos(\\theta)], [0, 1, vₓ⋅cos(\\theta) - v_y⋅sin(\\t\n",
+       "heta)]]"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grad_t =[grad(ti, w) for ti in t]\n",
+    "grad_t "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def hess(X, w):\n",
+    "    return [[diff(x, wi) for wi in w] for x in X]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABK0AAAAXBAMAAAA7CaHhAAAAMFBMVEX///8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAdt0yiUSZIs1UEGa7q++VedyHAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAJW0lEQVRoBeVaXYxbRxX+/LdeX3vX3ihKQRCx2oUikBpMJR4QVeOgFgJthFv1obxkN1WkVMqLi/oABRUL8VJAYH7EA0iJG0qpRMs6SLRIRNQRD0X9ywb6FiIMVSuRJighDdD0B87MmRnfmXuu16tcyENGzp0535xz5pzPn69v4mDLcm6pSS9sZmxZTnpfjRzJKgKkzLaZgs0UMxZDfaa0usluRXcRTCmKYNFdBNNzbLjTYQ8zbejODoYxCqJy+IVbUWyr1+bGrUn3q5IjWYaPvJvNUsOHJ1rxGOpTbnWz3Ur+EjapMslfwibl2GAv12OHOzbw87cNYyqI6uGX09Ut20hvwZCw4q4DaWRD8pewLHIEpYpmpUXw1j8CpnPRicDya+MdHZPb09Qxk3SlmxjH8UrqVmHS+6/eAEVmODaZY2rWw3OM/eBgvPEDWqrerb7GOxNWlmUVlNDVbC/6YBgrYXgIRzopH2LJX8IyyREWK9mPEVgbHAFm+9K2w0r/dEuoGDwXLeqYSbrSRIzj9ErqVmMpusoiR+qZQW1p5sqq24m6tFS94xsO23jhWKaghK5+CdweppCw6iKKwxRdSf4SlkWOsFbRPkjo7ag3UV3l/VLssxmP6I8NFUMdXtQxE3TFTYzj9ErqVmOyrrLIgdQzg9rSzGi8MUP06N7x5BjccOVYpqCErl4ADveDFBJWW0flcoquJH8JyyJHUKpsjoDCJdTp/nyGHSoN2TGGUgx2tvGGjpmgK24iFqiWUrcak3WVRY70M4PapjDnyYd7n+9P4W5cRpZlCkroir4JVoh/b0hYfRWlN1J0JflLWBY5vEJTjFIXmFvETvoUfpNdNtaVisEfUHhTx0zQFTfBad1V6lZjsq6yyIHUM11VUy/uJk/ufZY4m3KMWaagUFeRqi7IJWFYI129KetK8pewTHLYpqNtDXzIGo/e8hlE+7a18dGj7yJspgWsNXC4DexhF6urh/ch32Oo8J6F7hfP4cZX79veMDHRBVQu6ZgJumIiOIe9St0yJusqixzpZ9qqgjnWu+Kp/O31wo4DCyeV137A9F5c96KmY5mCQl2VX6c7oOI1NiQMX22hcEHWleQvYZnksHUWKyOcM0b5b9jbvLGD49EQecLUh+59TXyuA/yaXayuWocwb5h7HFjEDcC5RuFfJiZ3EUVaU8wEXTER5mQzSd0yJusqixzpZ/q1OSvWu+Ypv475k9hJJKm7uum92nX+ajEdyxQk6qrl5YKuOMC0Jl6foKvA/3+Ww5b6pZku1N+O1Zjt4lDn/fQB+dgZFMnO94ATp0+/Q8vvqX3A6KrcuxeVlkawt4+WekZ5EaDvPh1Te/v0n0c6ZgNd0YfRG1K3jKXr6kpzpJ/pleaMeO8lxRM95NVGqA/Ig278pvfKogtQi+lYpqBQVxG1t9LwckHCsNZCKeV+JflLWCY5oq8tqdHszzfweVM31YYCPXDXWx85rj5+823grLqzk9Toz8zS0o6/Li2t080ef0GpRxCN/FvX6eft5wHlqGLmh+rrU8VM0BUToVO4i9QtY7KussiRfqYrixePacKW471D8aR0NUSdGsYrrvfCeTJNBK2mY5mCQl2pp7/DPS7AXSWsvorKhOf2/1sOV+RKH4oSNdQXuXowqg8f+Q7VrjVyAdXLtNyr9t39CqXLyDGCaPd/VtX9KqYr4vjpvo6ZoCsmwiSxk8SYxmRdZZFj6nfO1hjrHYonX1em99LIuvM8FcsUlNAV0aq49IaEkbTpjSK+w0EZJX8JyyKHO/4e0PcYj7VVc7860I+ebtL3Yg/RJeQJDb4HMUN3bI7BA/j5xZiuKAZrbVzPMRN0xU2YJHaSutWYrKssckzNuq0x1ntZ8RTT1UOu9+B7EFOxLHwP4rfAvfT94A0Jq44w09W6CpyJOclfwrLI4Qp9AZUmFg58qqOfr9B7lb7QP97A3ICeFRrAJRzqk+8x9rfP7cTl93HHOobAd4FTMV2pmHq7coZjjK6SrRbb3ESf89qr1K3GtK4SabLIMTXrtkbde27b/fQLEtExN4jp6rjrvTq07jwrlkvbUSNrtosUlimI+uSX/X0w34texhqFxIaE0bPdL5paV4EzpZP8JSyTHLbO3bgfuc6f1H2GfuYrdm5u4uski1oHUH9ZPhXp/3uxj92trordcguty4URlOyeUZ/5b/HzlYqZGxxpkj/FGF0lW6VuFRHRv20ZPEvdaoz86V7Q9bwzypF6ZnCcPVv3ft3ckG5OmqfaELPm+WqP632mYd15ViwX6/2byUpnmYKoJ35ZXUW7tjeR/7CXTcLwyAL9jkt8h86UTvKXsExy2EpnbhugiuMFZT+x/9Mo79/TLt22oCosLQKP8s/p5rdPqyvs/w3KP13MDYG7jm5t3/T3Z29653fH/kGaUjHRPvosAxRjdBXwwsxpIpb6ytMNqVuNUYjEWBY5Us8MqnZFUu8Y1BpNapZ4Krx49icnzn7ixA20f6frPd9x7nqhWH7gTrxXGaksUxBTQ1erK07zI568q4Spdw3+hmYuCXMq35WxLHJwJrpedKv4wv03sfIiw05XypxrzTUYjl+9GKOrZKu220o/HmvWQrfs729kmSOokAvxj/MLpR9NkyPvwC8kN4GXoP/1NNxyjFEQ9cQvX1etMIZsCdOa8DcsS6K/70pJaWSRgzPR0/r5sl3G5yetoX5QVcP73Tnfnnc88ra6ejFWV63xPq2YOQ3Zp39vv+VZ7NdWU0uv7cUylkWOIDUf4R9nj+V5Jzo+oKzqqsUO2kV8/gBejpt27RijIKaGrp6uoob1Hc8SpjURbFiWAlgnkrBMcpgyHyx2xTdHPWTp8RUze1O+ueLZbHgxRldB/Uyedn9YyBB4aw/NTrBhGcsiR5BanylhptzyaLeoxGfs/tAsvGm5dN6zjWEZKw/TdFUVwiRMayLYsCwFsM4oYZnkMPU+8atdnxVKRzQ06LPSbuXg7wXYizG6CuqP6WogZAi8tYdmJ9iwjGWRI0itz5QwU2506q6tfbOOT48boyZt4ofHunFnu7aMqSCmhq6fXC4uNellnaaat7ySdLsaOZJVBMiX2a52AlybP8NzEhyLoT5TWt1kt7kd7eRRVyFHsggfKRuNP+XDbEWdmtkOdg1jFER98ivwuKbMk6XuNdXvlTY717j7SlNcE/E/3npNtJlZk5Wjralz/ReN0nqAWtR4XwAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\left [ \\left [ \\left [ 0, \\quad 0, \\quad 0\\right ], \\quad \\left [ 0, \\quad 0, \\quad 0\\right ], \\quad \\left [ 0, \\quad 0, \\quad - v_{x} \\cos{\\left (\\theta \\right )} + v_{y} \\sin{\\left (\\theta \\right )}\\right ]\\right ], \\quad \\left [ \\left [ 0, \\quad 0, \\quad 0\\right ], \\quad \\left [ 0, \\quad 0, \\quad 0\\right ], \\quad \\left [ 0, \\quad 0, \\quad - v_{x} \\sin{\\left (\\theta \\right )} - v_{y} \\cos{\\left (\\theta \\right )}\\right ]\\right ]\\right ]$$"
+      ],
+      "text/plain": [
+       "[[[0, 0, 0], [0, 0, 0], [0, 0, -vₓ⋅cos(\\theta) + v_y⋅sin(\\theta)]], [[0, 0, 0]\n",
+       ", [0, 0, 0], [0, 0, -vₓ⋅sin(\\theta) - v_y⋅cos(\\theta)]]]"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hessian_t = [hess(gti, w) for gti in grad_t]\n",
+    "hessian_t"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/autodiff/autodiff_types.hpp
+++ b/src/autodiff/autodiff_types.hpp
@@ -7,7 +7,7 @@ namespace ccd {
 static constexpr size_t N = 2 * 4;
 typedef Eigen::Matrix<double, 8, 1> Vector8d;
 typedef Eigen::Matrix<double, 8, 8> Matrix8d;
-typedef DScalar2<double, Vector8d> DScalar;
+typedef DScalar2<double, Vector8d, Matrix8d> DScalar;
 typedef DScalar::DVector2 DVector2;
 
 static inline DVector2 dvector(size_t index, const Eigen::Matrix<double, 2, 1> &v) {

--- a/src/opt/particles_problem.hpp
+++ b/src/opt/particles_problem.hpp
@@ -25,7 +25,7 @@ namespace opt {
     class ParticlesDisplProblem : public OptimizationProblem {
     public:
         ParticlesDisplProblem();
-        ~ParticlesDisplProblem() override;
+        virtual ~ParticlesDisplProblem() override;
 
         void initialize(const Eigen::MatrixX2d& V, const Eigen::MatrixX2i& E,
             const Eigen::MatrixX2d& U, CollisionConstraint& cstr);

--- a/src/opt/rigid_body_problem.cpp
+++ b/src/opt/rigid_body_problem.cpp
@@ -1,0 +1,91 @@
+#include "rigid_body_problem.hpp"
+
+#include <autodiff/finitediff.hpp>
+#include <utils/flatten.hpp>
+#include <utils/tensor.hpp>
+
+namespace ccd {
+
+namespace opt {
+    RigidBodyProblem::RigidBodyProblem() {}
+    RigidBodyProblem::~RigidBodyProblem() {}
+
+    void RigidBodyProblem::initialize(
+        ccd::physics::RigidBodySystem& rbs, CollisionConstraint& cstr)
+    {
+        model = std::make_shared<ccd ::physics::RigidBodySystem>(rbs);
+        model->assemble();
+
+        ParticlesDisplProblem::initialize(
+            model->vertices, model->edges, model->displacements, cstr);
+    }
+
+    double RigidBodyProblem::eval_f(const Eigen::VectorXd& x)
+    {
+        Eigen::MatrixXd Uk;
+        model->compute_displacements(x, Uk);
+        flatten(Uk);
+        return ParticlesDisplProblem::eval_f(Uk);
+    }
+
+    Eigen::VectorXd RigidBodyProblem::eval_grad_f(const Eigen::VectorXd& x)
+    {
+        // TODO: compute displacement, gradient and hessian together.
+        Eigen::MatrixXd Uk;
+        model->compute_displacements(x, Uk);
+        flatten(Uk);
+
+        Eigen::SparseMatrix<double> jac_uk_x;
+        model->compute_displacements_gradient(x, jac_uk_x);
+
+        Eigen::VectorXd grad_uk = ParticlesDisplProblem::eval_grad_f(Uk);
+        return grad_uk.transpose() * jac_uk_x;
+    }
+
+    Eigen::VectorXd RigidBodyProblem::eval_grad_f_approx(
+        const Eigen::VectorXd& x)
+    {
+        auto f = [&](const Eigen::VectorXd& v) -> double { return eval_f(v); };
+
+        Eigen::VectorXd grad;
+        ccd::finite_gradient(x, f, grad);
+        return grad;
+    }
+
+    Eigen::SparseMatrix<double> RigidBodyProblem::eval_hessian_f_sparse(
+        const Eigen::VectorXd& x)
+    {
+        // TODO: compute displacement, gradient and hessian together.
+        Eigen::MatrixXd Uk;
+        model->compute_displacements(x, Uk);
+        flatten(Uk);
+
+        std::vector<Eigen::SparseMatrix<double>> hess_uk_x;
+        model->compute_displacements_hessian(x, hess_uk_x);
+
+        Eigen::SparseMatrix<double> jac_uk_x;
+        model->compute_displacements_gradient(x, jac_uk_x);
+
+        Eigen::SparseMatrix<double> hess_uk
+            = ParticlesDisplProblem::eval_hessian_f_sparse(Uk);
+        Eigen::VectorXd grad_uk = ParticlesDisplProblem::eval_grad_f(Uk);
+
+        // chain rule
+        return jac_uk_x.transpose() * hess_uk * jac_uk_x
+            + tensor::multiply(grad_uk, hess_uk_x);
+    }
+
+    Eigen::MatrixXd RigidBodyProblem::eval_hessian_f_approx(
+        const Eigen::VectorXd& x)
+    {
+
+        auto f = [&](const Eigen::VectorXd& v) -> Eigen::VectorXd {
+            return eval_grad_f(v);
+        };
+
+        Eigen::MatrixXd hess;
+        ccd::finite_jacobian(x, f, hess);
+        return hess;
+    }
+} // namespace opt
+} // namespace ccd

--- a/src/opt/rigid_body_problem.hpp
+++ b/src/opt/rigid_body_problem.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <opt/particles_problem.hpp>
+#include <physics/rigid_body_system.hpp>
+
+namespace ccd {
+
+namespace opt {
+
+    class RigidBodyProblem : public ParticlesDisplProblem {
+    public:
+        RigidBodyProblem();
+        ~RigidBodyProblem() override;
+
+        void initialize(ccd::physics::RigidBodySystem& rbs,
+            CollisionConstraint& cstr);
+
+        double eval_f(const Eigen::VectorXd& x) override;
+        Eigen::VectorXd eval_grad_f(const Eigen::VectorXd& x) override;
+        Eigen::VectorXd eval_grad_f_approx(const Eigen::VectorXd& x);
+
+        Eigen::SparseMatrix<double> eval_hessian_f_sparse(
+            const Eigen::VectorXd& x) override;
+        Eigen::MatrixXd eval_hessian_f_approx(
+            const Eigen::VectorXd& x);
+        std::shared_ptr<ccd::physics::RigidBodySystem> model;
+
+    };
+} // namespace opt
+} // namespace ccd

--- a/src/physics/rigid_body.cpp
+++ b/src/physics/rigid_body.cpp
@@ -1,0 +1,245 @@
+#include <physics/rigid_body.hpp>
+
+#include <Eigen/Geometry>
+
+#include <autodiff/finitediff.hpp>
+#include <logger.hpp>
+#include <utils/flatten.hpp>
+
+namespace ccd {
+
+namespace physics {
+
+    RigidBody::RigidBody(const Eigen::MatrixX2d& vertices,
+        const Eigen::MatrixX2i& edges, const Eigen::Vector2d& position,
+        const Eigen::Vector3d& velocity)
+        : vertices(vertices)
+        , edges(edges)
+        , position(position)
+        , velocity(velocity)
+    {
+        spdlog::trace("rigid_body velocity={},{},{}", velocity[0], velocity[1],
+            velocity[2]);
+    }
+
+    Eigen::MatrixXd RigidBody::world_displacements() const
+    {
+        return world_displacements(velocity);
+    }
+
+    template <typename T>
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
+    RigidBody::world_displacements(const Eigen::Matrix<T, 3, 1>& vel) const
+    {
+        typedef Eigen::Translation<T, 2> Translation2d;
+        typedef Eigen::Rotation2D<T> Rotation2Dd;
+        typedef Eigen::Matrix<T, 3, 3> Matrix3d;
+        typedef Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> MatrixXd;
+        typedef Eigen::Matrix<T, Eigen::Dynamic, 3> MatrixX3d;
+
+        // create transform matrix matrix
+        Matrix3d Tm = Eigen::Transform<T, 2, Eigen::Affine>(
+            Translation2d(vel.x(), vel.y())
+            * Translation2d(T(position.x()), T(position.y()))
+            * Rotation2Dd(vel(2))
+            * Translation2d(T(position.x()), -T(position.y())))
+                          .matrix();
+
+        MatrixXd v = world_vertices().cast<T>();
+
+        MatrixX3d hvertices = v.rowwise().homogeneous();
+        MatrixX3d tvertices = hvertices * Tm.transpose();
+
+        MatrixXd displacements;
+        displacements = tvertices.rowwise().hnormalized();
+        displacements -= v;
+
+        return displacements;
+    }
+
+    Eigen::MatrixX2d RigidBody::world_vertices() const
+    {
+        return vertices.rowwise() + position.transpose();
+    }
+
+    Eigen::MatrixXd RigidBody::world_displacements_gradient(
+        const Eigen::Vector3d& vel) const
+    {
+        RBDiff::activate();
+        RBDiff::D1Vector3 dvel = RBDiff::d1vars(0, vel);
+        RBDiff::D1MatrixXd dx = world_displacements<RBDiff::DScalar1>(dvel);
+
+        flatten<RBDiff::DScalar1>(dx);
+        return RBDiff::get_gradient(dx);
+    }
+
+    std::vector<Eigen::Matrix3d> RigidBody::world_displacements_hessian(
+        const Eigen::Vector3d& vel) const
+    {
+
+        RBDiff::activate();
+        RBDiff::D2Vector3 dvel = RBDiff::d2vars(0, vel);
+        RBDiff::D2MatrixXd dx = world_displacements<RBDiff::DScalar2>(dvel);
+
+        flatten<RBDiff::DScalar2>(dx);
+        return RBDiff::get_hessian(dx);
+    }
+
+    Eigen::MatrixXd RigidBody::world_displacements_gradient_finite(
+        const Eigen::Vector3d& vel) const
+    {
+        auto f = [&](const Eigen::VectorXd& v) -> Eigen::VectorXd {
+            assert(v.rows() == 3);
+            Eigen::Vector3d v3 = v;
+            Eigen::MatrixXd d = world_displacements(v3);
+
+            flatten<double>(d);
+            return d;
+        };
+
+        Eigen::MatrixXd grad;
+        ccd::finite_jacobian(vel, f, grad);
+        return grad;
+    }
+
+    std::vector<Eigen::MatrixX2d> RigidBody::world_displacements_gradient_exact(
+        const Eigen::Vector3d& vel) const
+    {
+        typedef Eigen::Transform<double, 2, Eigen::Affine> AffineTransform;
+        Eigen::Matrix3d T_c
+            = AffineTransform(Eigen::Translation2d(position.x(), position.y()))
+                  .matrix();
+        Eigen::Matrix3d T_negc = AffineTransform(
+            Eigen::Translation2d(-position.x(), -position.y()))
+                                     .matrix();
+        Eigen::Matrix3d T_xy
+            = AffineTransform(Eigen::Translation2d(vel.x(), vel.y())).matrix();
+        double θ = vel(2);
+        Eigen::Matrix3d R_θ = AffineTransform(Eigen::Rotation2Dd(θ)).matrix();
+
+        Eigen::Matrix3d gradx_T
+            = AffineTransform(Eigen::Translation2d(1, 0)).matrix() * T_c * R_θ
+            * T_negc;
+        Eigen::Matrix3d grady_T = Eigen::Transform<double, 2, Eigen::Affine>(
+                                      Eigen::Translation2d(0, 1))
+                                      .matrix()
+            * T_c * R_θ * T_negc;
+        Eigen::Matrix3d gradθ_R;
+        // clang-format off
+    gradθ_R <<
+        -sin(θ), -cos(θ), 0,
+         cos(θ), -sin(θ), 0,
+              0,       0, 1;
+        // clang-format on
+        Eigen::Matrix3d gradθ_T = T_xy * T_c * gradθ_R * T_negc;
+
+        const auto& this_vertices = world_vertices();
+        auto transform_vertices
+            = [&this_vertices](const Eigen::Matrix3d& T) -> Eigen::MatrixX2d {
+            return (this_vertices.rowwise().homogeneous() * T.transpose())
+                .rowwise()
+                .hnormalized();
+        };
+
+        std::vector<Eigen::MatrixX2d> gradient;
+        gradient.reserve(3);
+        gradient.push_back(transform_vertices(gradx_T));
+        gradient.push_back(transform_vertices(grady_T));
+        gradient.push_back(transform_vertices(gradθ_T));
+
+        return gradient;
+    }
+
+    std::vector<std::vector<Eigen::MatrixX2d>>
+    RigidBody::compute_world_displacements_hessian() const
+    {
+        Eigen::Matrix3d T_c = Eigen::Transform<double, 2, Eigen::Affine>(
+            Eigen::Translation2d(position.x(), position.y()))
+                                  .matrix();
+        Eigen::Matrix3d T_negc = Eigen::Transform<double, 2, Eigen::Affine>(
+            Eigen::Translation2d(-position.x(), -position.y()))
+                                     .matrix();
+        Eigen::Matrix3d T_xy = Eigen::Transform<double, 2, Eigen::Affine>(
+            Eigen::Translation2d(velocity.x(), velocity.y()))
+                                   .matrix();
+        double θ = velocity(2);
+        Eigen::Matrix3d R_θ
+            = Eigen::Transform<double, 2, Eigen::Affine>(Eigen::Rotation2Dd(θ))
+                  .matrix();
+
+        Eigen::Matrix3d gradx_T_xy = Eigen::Transform<double, 2, Eigen::Affine>(
+            Eigen::Translation2d(1, 0))
+                                         .matrix();
+        Eigen::Matrix3d grady_T_xy = Eigen::Transform<double, 2, Eigen::Affine>(
+            Eigen::Translation2d(0, 1))
+                                         .matrix();
+        Eigen::Matrix3d gradx_T = gradx_T_xy * T_c * R_θ * T_negc;
+        Eigen::Matrix3d grady_T = grady_T_xy * T_c * R_θ * T_negc;
+        Eigen::Matrix3d gradθ_R;
+        // clang-format off
+    // R_θ <<
+    //     cos(θ), -sin(θ), 0,
+    //     sin(θ),  cos(θ), 0,
+    //          0,       0, 0;
+    gradθ_R <<
+        -sin(θ), -cos(θ), 0,
+         cos(θ), -sin(θ), 0,
+              0,       0, 0;
+    // gradθ_gradθ_R <<
+    //     -cos(θ),  sin(θ), 0,
+    //     -sin(θ), -cos(θ), 0,
+    //           0,       0, 0;
+        // clang-format on
+        Eigen::Matrix3d gradθ_T = T_xy * T_c * gradθ_R * T_negc;
+
+        Eigen::Matrix3d gradx_gradx_T = Eigen::Matrix3d::Zero();
+        Eigen::Matrix3d gradx_grady_T = Eigen::Matrix3d::Zero();
+        Eigen::Matrix3d gradx_gradθ_T = gradx_T_xy * T_c * gradθ_R * T_negc;
+
+        Eigen::Matrix3d grady_gradx_T = Eigen::Matrix3d::Zero();
+        Eigen::Matrix3d grady_grady_T = Eigen::Matrix3d::Zero();
+        Eigen::Matrix3d grady_gradθ_T = grady_T_xy * T_c * gradθ_R * T_negc;
+
+        Eigen::Matrix3d gradθ_gradx_T = gradx_gradθ_T;
+        Eigen::Matrix3d gradθ_grady_T = grady_gradθ_T;
+        Eigen::Matrix3d gradθ_gradθ_T = T_xy * T_c * -R_θ * T_negc;
+
+        Eigen::MatrixX3d homogeneous_vertices(vertices.rows(), 3);
+        homogeneous_vertices.leftCols(2) = world_vertices();
+        ;
+        homogeneous_vertices.col(2).setOnes();
+
+        std::vector<std::vector<Eigen::MatrixX2d>> hessian(
+            3, std::vector<Eigen::MatrixX2d>());
+
+        const auto& this_vertices = world_vertices();
+        auto transform_vertices
+            = [&this_vertices](const Eigen::Matrix3d& T) -> Eigen::MatrixX2d {
+            return (this_vertices.rowwise().homogeneous() * T.transpose())
+                .rowwise()
+                .hnormalized();
+        };
+
+        // ∇_x∇U
+        hessian[0].reserve(3);
+        hessian[0].push_back(transform_vertices(gradx_gradx_T));
+        hessian[0].push_back(transform_vertices(gradx_grady_T));
+        hessian[0].push_back(transform_vertices(gradx_gradθ_T));
+
+        // ∇_y∇U
+        hessian[1].reserve(3);
+        hessian[1].push_back(transform_vertices(grady_gradx_T));
+        hessian[1].push_back(transform_vertices(grady_grady_T));
+        hessian[1].push_back(transform_vertices(grady_gradθ_T));
+
+        // ∇_θ∇U
+        hessian[2].reserve(3);
+        hessian[2].push_back(transform_vertices(gradθ_gradx_T));
+        hessian[2].push_back(transform_vertices(gradθ_grady_T));
+        hessian[2].push_back(transform_vertices(gradθ_gradθ_T));
+
+        return hessian;
+    }
+
+} // namespace physics
+} // namespace ccd

--- a/src/physics/rigid_body.hpp
+++ b/src/physics/rigid_body.hpp
@@ -1,0 +1,130 @@
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/Sparse>
+
+#include <physics/center_of_mass.hpp>
+
+#include <autodiff/autodiff.h>
+
+namespace ccd {
+namespace physics {
+
+    namespace RBDiff {
+        static constexpr size_t NUM_VARS = 3;
+        typedef Eigen::Vector3d Vector3d;
+        typedef Eigen::Matrix3d Matrix3d;
+        typedef DScalar1<double, Vector3d> DScalar1;
+        typedef DScalar2<double, Vector3d, Matrix3d> DScalar2;
+        typedef Eigen::Matrix<DScalar1, 3, 1> D1Vector3;
+        typedef Eigen::Matrix<DScalar2, 3, 1> D2Vector3;
+        typedef Eigen::Matrix<DScalar1, Eigen::Dynamic, Eigen::Dynamic>
+            D1MatrixXd;
+        typedef Eigen::Matrix<DScalar2, Eigen::Dynamic, Eigen::Dynamic>
+            D2MatrixXd;
+        typedef Eigen::Matrix<DScalar1, Eigen::Dynamic, 1> D1VectorXd;
+        typedef Eigen::Matrix<DScalar2, Eigen::Dynamic, 1> D2VectorXd;
+
+        inline void activate() { DiffScalarBase::setVariableCount(NUM_VARS); }
+
+        inline D1Vector3 d1vars(const size_t i, const Vector3d& v)
+        {
+            return D1Vector3(DScalar1(i, v[0]), DScalar1(i + 1, v[1]),
+                DScalar1(i + 2, v[2]));
+        }
+
+        inline D2Vector3 d2vars(const size_t i, const Vector3d& v)
+        {
+            return D2Vector3(DScalar2(i, v[0]), DScalar2(i + 1, v[1]),
+                DScalar2(i + 2, v[2]));
+        }
+
+        inline Eigen::MatrixXd get_gradient(const D1VectorXd& x)
+        {
+            Eigen::MatrixXd grad(x.rows(), NUM_VARS);
+            for (int i = 0; i < x.rows(); ++i) {
+                grad.row(i) = x(i).getGradient();
+            }
+            return grad;
+        }
+
+        inline std::vector<Matrix3d> get_hessian(const D2VectorXd& x)
+        {
+            std::vector<Matrix3d> hess;
+            hess.reserve(x.rows());
+
+            for (int i = 0; i < x.rows(); ++i) {
+                hess.push_back(x(i).getHessian());
+            }
+            return hess;
+        }
+
+    } // namespace RBDiff
+
+    class RigidBody {
+    public:
+        RigidBody(const Eigen::MatrixX2d& vertices,
+            const Eigen::MatrixX2i& edges, const Eigen::Vector2d& position,
+            const Eigen::Vector3d& velocity);
+
+        Eigen::MatrixXd world_displacements() const;
+
+        template <typename T>
+        Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> world_displacements(
+            const Eigen::Matrix<T, 3, 1>& velocity) const;
+
+        Eigen::MatrixX2d world_vertices() const;
+
+        /// word_displacement_gradient: computes gradient for each
+        /// displacement, xy.
+        ///
+        /// Returns: Matrix size (2n * 3)
+        Eigen::MatrixXd world_displacements_gradient(
+            const Eigen::Vector3d& velocity) const;
+
+        /// word_displacement_gradient: computes hessian for each
+        /// displacement, xy.
+        ///
+        /// Returns: Tensor size (2n * 3 * 3);
+        ///          really a list of 3 * 3 matrices
+        std::vector<Eigen::Matrix3d> world_displacements_hessian(
+            const Eigen::Vector3d& velocity) const;
+
+        Eigen::MatrixXd world_displacements_gradient_finite(
+            const Eigen::Vector3d& velocity) const;
+
+        std::vector<Eigen::MatrixX2d> world_displacements_gradient_exact(
+            const Eigen::Vector3d& velocity) const;
+
+        std::vector<std::vector<Eigen::MatrixX2d>>
+        compute_world_displacements_hessian() const;
+
+        /// \brief vertices as distances from the center of mass
+        Eigen::MatrixX2d vertices;
+        Eigen::MatrixX2i edges;
+
+        /// \brief position: position of the object in world space
+        Eigen::Vector2d position;
+
+        /// \brief velocity: linear and angular velicity
+        Eigen::Vector3d velocity;
+
+        ///
+        /// \brief Centered: Factory method to create a RB with
+        /// with position equal to current center of mass.
+        /// \param vertices
+        /// \param edges
+        /// \param velocity
+        /// \return
+        ///
+        static inline RigidBody Centered(const Eigen::MatrixXd& vertices,
+            const Eigen::MatrixX2i& edges, const Eigen::Vector3d& velocity)
+        {
+            Eigen::RowVector2d x = center_of_mass(vertices, edges);
+            Eigen::MatrixX2d centered_vertices = vertices.rowwise() - x;
+            return RigidBody(centered_vertices, edges, x, velocity);
+        }
+    };
+
+} // namespace physics
+} // namespace ccd

--- a/src/utils/flatten.hpp
+++ b/src/utils/flatten.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Eigen/Core>
+
+namespace ccd {
+
+template <typename T>
+inline void flatten(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x)
+{
+    x.resize(x.size(), 1);
+}
+
+template <typename T>
+inline void unflatten(
+    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& x, const int cols)
+{
+    assert(x.size() % cols == 0);
+    x.resize(x.size() / cols, cols);
+}
+} // namespace ccd

--- a/src/utils/tensor.hpp
+++ b/src/utils/tensor.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <Eigen/Sparse>
+
+namespace ccd {
+namespace tensor {
+
+    Eigen::SparseMatrix<double> multiply(const Eigen::VectorXd& x,
+        const std::vector<Eigen::SparseMatrix<double>>& y)
+    {
+        assert(x.rows() == int(y.size()));
+        int num_rows, num_cols;
+        num_rows = y[0].rows();
+        num_cols = y[0].cols();
+
+        Eigen::SparseMatrix<double> m;
+        m.resize(num_rows, num_cols);
+        m.setZero();
+
+        for (size_t i = 0; i < y.size(); ++i) {
+            assert(y[i].rows() == num_rows);
+            assert(y[i].cols() == num_cols);
+            m += x[int(i)] * y[i];
+        }
+        return m;
+    }
+} // namespace tensor
+} // namespace ccd

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,8 +26,10 @@ add_executable(unit_tests
     opt/test_barriers.cpp
     opt/test_volume_constraint.cpp
     opt/test_barrier_constraint.cpp
+    opt/test_rigid_body_problem.cpp
 
     physics/test_rigid_body.cpp
+    physics/test_rigid_body_system.cpp
 
 )
 

--- a/tests/opt/test_rigid_body_problem.cpp
+++ b/tests/opt/test_rigid_body_problem.cpp
@@ -1,0 +1,166 @@
+#include <array>
+#include <iomanip>
+#include <iostream>
+
+#include <catch2/catch.hpp>
+
+#include <igl/PI.h>
+
+#include <autodiff/finitediff.hpp>
+#include <opt/rigid_body_problem.hpp>
+
+// ---------------------------------------------------
+// Tests
+// ---------------------------------------------------
+
+TEST_CASE(
+    "Rigid Body Problem Functional", "[RB][RB-Problem][RB-Problem-functional]")
+{
+
+    Eigen::MatrixX2d vertices(4, 2);
+    Eigen::MatrixX2i edges(4, 2);
+    Eigen::Vector3d vel_1, vel_2;
+
+    Eigen::MatrixX2d expected(4, 2);
+
+    vertices << -0.5, -0.5, 0.5, -0.5, 0.5, 0.5, -0.5, 0.5;
+    edges << 0, 1, 1, 2, 2, 3, 3, 0;
+
+    // expected displacement of nodes
+    double dx = 0.0;
+
+    SECTION("Translation Case")
+    {
+        vel_1 << 0.5, 0.5, 0.0;
+        vel_2 << 1.0, 1.0, 0.0;
+        dx = 0.5 * 0.5 * 8;
+    }
+
+    SECTION("90 Deg Rotation Case")
+    {
+        vel_1 << 0.0, 0.0, 0.5 * M_PI;
+        vel_2 << 0.0, 0.0, M_PI;
+        dx = 1.0 * 1.0 * 4;
+    }
+
+    using namespace ccd::physics;
+    using namespace ccd::opt;
+
+    auto rbs = RigidBodySystem();
+    rbs.add_rigid_body(RigidBody::Centered(vertices, edges, vel_1));
+    rbs.add_rigid_body(RigidBody::Centered(vertices, edges, vel_2));
+
+    auto rbp = RigidBodyProblem();
+    auto cstr = VolumeConstraint();
+    rbp.initialize(rbs, cstr);
+
+    // displacement cases
+    Eigen::VectorXd x(6);
+    x << vel_1, vel_2;
+    double fx = rbp.eval_f(x);
+    CHECK(fx == Approx(0.0));
+
+    x << 2 * vel_1, vel_2;
+    fx = rbp.eval_f(x);
+    CHECK(fx == Approx(dx / 2));
+}
+
+TEST_CASE(
+    "Rigid Body Problem Gradient", "[RB][RB-Problem][RB-Problem-gradient]")
+{
+
+    Eigen::MatrixX2d vertices(4, 2);
+    Eigen::MatrixX2i edges(4, 2);
+    Eigen::Vector3d vel_1, vel_2;
+
+    Eigen::MatrixX2d expected(4, 2);
+
+    vertices << -0.5, -0.5, 0.5, -0.5, 0.5, 0.5, -0.5, 0.5;
+    edges << 0, 1, 1, 2, 2, 3, 3, 0;
+
+    SECTION("Translation Case")
+    {
+        vel_1 << 0.5, 0.5, 0.0;
+        vel_2 << 1.0, 1.0, 0.0;
+    }
+
+    SECTION("90 Deg Rotation Case")
+    {
+        vel_1 << 0.0, 0.0, 0.5 * M_PI;
+        vel_2 << 0.0, 0.0, M_PI;
+    }
+    SECTION("Translation and Rotation Case")
+    {
+        vel_1 << 0.5, 0.5, 0.5 * M_PI;
+        vel_2 << 1.0, 1.0, M_PI;
+    }
+
+    using namespace ccd::physics;
+    using namespace ccd::opt;
+
+    auto rbs = RigidBodySystem();
+    rbs.add_rigid_body(RigidBody::Centered(vertices, edges, vel_1));
+    rbs.add_rigid_body(RigidBody::Centered(vertices, edges, vel_2));
+
+    auto rbp = RigidBodyProblem();
+    auto cstr = VolumeConstraint();
+    rbp.initialize(rbs, cstr);
+
+    // displacement cases
+    Eigen::VectorXd x(6);
+    x << vel_1, vel_2;
+    Eigen::VectorXd grad_fx = rbp.eval_grad_f(x);
+    Eigen::VectorXd grad_fx_approx = rbp.eval_grad_f_approx(x);
+
+    CHECK(ccd::compare_gradient(grad_fx, grad_fx_approx));
+}
+
+TEST_CASE(
+    "Rigid Body Problem Hessian", "[RB][RB-Problem][RB-Problem-hessian]")
+{
+
+    Eigen::MatrixX2d vertices(4, 2);
+    Eigen::MatrixX2i edges(4, 2);
+    Eigen::Vector3d vel_1, vel_2;
+
+    Eigen::MatrixX2d expected(4, 2);
+
+    vertices << -0.5, -0.5, 0.5, -0.5, 0.5, 0.5, -0.5, 0.5;
+    edges << 0, 1, 1, 2, 2, 3, 3, 0;
+
+    SECTION("Translation Case")
+    {
+        vel_1 << 0.5, 0.5, 0.0;
+        vel_2 << 1.0, 1.0, 0.0;
+    }
+
+    SECTION("90 Deg Rotation Case")
+    {
+        vel_1 << 0.0, 0.0, 0.5 * M_PI;
+        vel_2 << 0.0, 0.0, M_PI;
+    }
+    SECTION("Translation and Rotation Case")
+    {
+        vel_1 << 0.5, 0.5, 0.5 * M_PI;
+        vel_2 << 1.0, 1.0, M_PI;
+    }
+
+    using namespace ccd::physics;
+    using namespace ccd::opt;
+
+    auto rbs = RigidBodySystem();
+    rbs.add_rigid_body(RigidBody::Centered(vertices, edges, vel_1));
+    rbs.add_rigid_body(RigidBody::Centered(vertices, edges, vel_2));
+
+    auto rbp = RigidBodyProblem();
+    auto cstr = VolumeConstraint();
+    rbp.initialize(rbs, cstr);
+
+    // displacement cases
+    Eigen::VectorXd x(6);
+    x << vel_1, vel_2;
+    Eigen::MatrixXd hess_fx = rbp.eval_hessian_f_sparse(x).toDense();
+    Eigen::MatrixXd hess_fx_approx = rbp.eval_hessian_f_approx(x);
+
+    CHECK(ccd::compare_jacobian(hess_fx, hess_fx_approx));
+}

--- a/tests/physics/test_rigid_body.cpp
+++ b/tests/physics/test_rigid_body.cpp
@@ -1,11 +1,12 @@
 #include <iomanip>
 #include <iostream>
+#include <array>
 
 #include <catch2/catch.hpp>
 
 #include <igl/PI.h>
 
-#include <physics/rigid_body_system.hpp>
+#include <physics/rigid_body.hpp>
 
 // ---------------------------------------------------
 // Tests
@@ -53,4 +54,123 @@ TEST_CASE("Rigid Body Transform", "[RB][RB-transform]")
     //        ", ", ", ", "", "", " << ", ";");
     //    std::cout << expected.format(CommaInitFmt) << std::endl;
     //    std::cout << actual.format(CommaInitFmt) << std::endl;
+}
+
+TEST_CASE("Rigid Body Gradient", "[RB][RB-gradient]")
+{
+
+    Eigen::MatrixX2d vertices(4, 2);
+    Eigen::MatrixX2i edges(4, 2);
+    Eigen::Vector3d velocity;
+
+    Eigen::MatrixXd expected(8, 3);
+
+    vertices << -0.5, -0.5, 0.5, -0.5, 0.5, 0.5, -0.5, 0.5;
+    edges << 0, 1, 1, 2, 2, 3, 3, 0;
+
+    SECTION("Translation Case")
+    {
+        velocity << 0.5, 0.5, 0.0;
+
+    }
+
+    SECTION("90 Deg Rotation Case")
+    {
+        velocity << 0.0, 0.0, 0.5 * M_PI;
+
+    }
+
+    SECTION("Translation and Rotation Case")
+    {
+        velocity << 0.5, 0.5, 0.5 * M_PI;
+    }
+
+    for (int i=0; i < 4; i++) {
+        // x entry
+        expected.row(i) << 1, 0, - vertices(i,0) * sin(velocity.z()) - vertices(i,1) * cos(velocity.z());
+        // y entry
+        expected.row(4 + i) << 0, 1, vertices(i,0) * cos(velocity.z()) - vertices(i,1) * sin(velocity.z());
+    }
+
+    using namespace ccd::physics;
+
+    auto rb = RigidBody::Centered(vertices, edges, velocity);
+    Eigen::MatrixXd actual = rb.world_displacements_gradient(rb.velocity);
+    Eigen::MatrixXd finite = rb.world_displacements_gradient_finite(rb.velocity);
+    std::vector<Eigen::MatrixX2d> exact = rb.world_displacements_gradient_exact(rb.velocity);
+
+    CHECK((expected - actual).squaredNorm() < 1E-6);
+    CHECK((expected - finite).squaredNorm() < 1E-6);
+    // TODO: use exact instead of expected
+    Eigen::IOFormat HeavyFmt(4, 0, ", ", ";\n", "[", "]", "[", "]");
+
+//    std::cout << "expected" << std::endl;
+//    std::cout << expected.format(HeavyFmt) << std::endl;
+//    std::cout << "actual" << std::endl;
+//    std::cout << actual.format(HeavyFmt) << std::endl;
+//    std::cout << "finite" << std::endl;
+//    std::cout << finite.format(HeavyFmt) << std::endl;
+//    std::cout << "exact" << std::endl;
+//    for(auto &m: exact){
+//        std::cout << m.format(HeavyFmt) << std::endl;
+//    }
+}
+
+TEST_CASE("Rigid Body Hessian", "[RB][RB-hessian]")
+{
+
+    Eigen::MatrixX2d vertices(4, 2);
+    Eigen::MatrixX2i edges(4, 2);
+    Eigen::Vector3d velocity;
+
+    std::array<Eigen::Matrix3d, 8> expected;
+
+    vertices << -0.5, -0.5, 0.5, -0.5, 0.5, 0.5, -0.5, 0.5;
+    edges << 0, 1, 1, 2, 2, 3, 3, 0;
+
+    SECTION("Translation Case")
+    {
+        velocity << 0.5, 0.5, 0.0;
+
+    }
+
+    SECTION("90 Deg Rotation Case")
+    {
+        velocity << 0.0, 0.0, 0.5 * M_PI;
+
+    }
+
+    SECTION("Translation and Rotation Case")
+    {
+        velocity << 0.5, 0.5, 0.5 * M_PI;
+    }
+
+    for (int i=0; i < 4; ++i) {
+        Eigen::Matrix3d h = Eigen::Matrix3d::Zero(3,3);
+        h(2,2) = - vertices(i,0) * cos(velocity.z()) + vertices(i,1) * sin(velocity.z());
+        expected[size_t(i)] = h;
+    }
+    for (int i=0; i < 4; ++i) {
+        Eigen::Matrix3d h = Eigen::Matrix3d::Zero(3,3);
+        h(2,2) = - vertices(i,0) * sin(velocity.z()) - vertices(i,1) * cos(velocity.z());
+        expected[size_t(i) + 4] = h;
+    }
+
+    using namespace ccd::physics;
+
+    auto rb = RigidBody::Centered(vertices, edges, velocity);
+    std::vector<Eigen::Matrix3d> actual = rb.world_displacements_hessian(rb.velocity);
+
+    Eigen::IOFormat HeavyFmt(4, 0, ", ", ";\n", "[", "]", "[", "]");
+
+    REQUIRE(expected.size() == actual.size());
+    for (uint i=0; i < 8; ++i) {
+        CHECK((expected[i] - actual[i]).squaredNorm() < 1E-6);
+//        std::cout << i << " ====================== " << std::endl;
+//        std::cout << "expected" << std::endl;
+//        std::cout << expected[i].format(HeavyFmt) << std::endl;
+//        std::cout << "actual" << std::endl;
+//        std::cout << actual[i].format(HeavyFmt) << std::endl;
+    }
+
 }

--- a/tests/physics/test_rigid_body_system.cpp
+++ b/tests/physics/test_rigid_body_system.cpp
@@ -1,0 +1,203 @@
+#include <array>
+#include <iomanip>
+#include <iostream>
+
+#include <catch2/catch.hpp>
+
+#include <igl/PI.h>
+
+#include <physics/rigid_body_system.hpp>
+
+// ---------------------------------------------------
+// Tests
+// ---------------------------------------------------
+
+TEST_CASE("Rigid Body System Transform", "[RB][RB-System][RB-System-transform]")
+{
+
+    Eigen::MatrixX2d vertices(4, 2);
+    Eigen::MatrixX2i edges(4, 2);
+    Eigen::Vector3d vel_1, vel_2;
+
+    Eigen::MatrixX2d expected(4, 2);
+
+    vertices << -0.5, -0.5, 0.5, -0.5, 0.5, 0.5, -0.5, 0.5;
+    edges << 0, 1, 1, 2, 2, 3, 3, 0;
+
+    SECTION("Translation Case")
+    {
+        vel_1 << 0.5, 0.5, 0.0;
+        vel_2 << 1.0, 1.0, 0.0;
+
+        // expected displacements
+        expected.resize(8, 2);
+        expected.block(0, 0, 4, 2)
+            = vel_1.segment(0, 2).transpose().replicate(4, 1);
+        expected.block(4, 0, 4, 2)
+            = vel_2.segment(0, 2).transpose().replicate(4, 1);
+    }
+
+    SECTION("90 Deg Rotation Case")
+    {
+        vel_1 << 0.0, 0.0, 0.5 * M_PI;
+        vel_2 << 0.0, 0.0, M_PI;
+        expected.resize(8, 2);
+        expected.block(0, 0, 4, 2) << 1.0, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0, -1.0;
+        expected.block(4, 0, 4, 2) << 1.0, 1.0, -1.0, 1.0, -1.0, -1.0, 1.0,
+            -1.0;
+    }
+
+    using namespace ccd::physics;
+
+    auto rbs = RigidBodySystem();
+    rbs.add_rigid_body(RigidBody::Centered(vertices, edges, vel_1));
+    rbs.add_rigid_body(RigidBody::Centered(vertices, edges, vel_2));
+    rbs.assemble();
+
+    Eigen::MatrixXd actual = rbs.displacements;
+    CHECK((expected - actual).squaredNorm() < 1E-6);
+
+    //    Eigen::IOFormat CommaInitFmt(Eigen::StreamPrecision,
+    //    Eigen::DontAlignCols,
+    //        ", ", ", ", "", "", " << ", ";");
+    //    std::cout << expected.format(CommaInitFmt) << std::endl;
+    //    std::cout << actual.format(CommaInitFmt) << std::endl;
+}
+
+TEST_CASE("Rigid Body System Gradient", "[RB][RB-System][RB-System-gradient]")
+{
+
+    Eigen::MatrixX2d vertices(4, 2);
+    Eigen::MatrixX2i edges(4, 2);
+    Eigen::Vector3d vel_1, vel_2;
+
+    Eigen::MatrixXd expected(16, 6);
+
+    vertices << -0.5, -0.5, 0.5, -0.5, 0.5, 0.5, -0.5, 0.5;
+    edges << 0, 1, 1, 2, 2, 3, 3, 0;
+
+    SECTION("Translation Case")
+    {
+        vel_1 << 0.5, 0.5, 0.0;
+        vel_2 << 1.0, 1.0, 0.0;
+
+        // expected displacements
+        for (uint i = 0; i < 4; ++i) {
+            // x - derivative RB 1
+            expected.row(i) << 1, 0, -vertices(i, 1), 0, 0, 0;
+            // x - derivative RB 2
+            expected.row(4 + i) << 0, 0, 0, 1, 0, -vertices(i, 1);
+            // y - derivative RB 1
+            expected.row(8 + i) << 0, 1, vertices(i, 0), 0, 0, 0;
+            // y - derivative RB 1
+            expected.row(12 + i) << 0, 0, 0, 0, 1, vertices(i, 0);
+        }
+    }
+
+    SECTION("90 Deg Rotation Case")
+    {
+        vel_1 << 0.0, 0.0, 0.5 * M_PI;
+        vel_2 << 0.0, 0.0, M_PI;
+
+        // expected displacements
+        for (uint i = 0; i < 4; ++i) {
+            // x - derivative RB 1
+            double dtheta = -vertices(i, 0) * sin(vel_1(2))
+                - vertices(i, 1) * cos(vel_1(2));
+            expected.row(i) << 1, 0, dtheta, 0, 0, 0;
+            // x - derivatibe RB 2
+            dtheta = -vertices(i, 0) * sin(vel_2(2))
+                - vertices(i, 1) * cos(vel_2(2));
+            expected.row(4 + i) << 0, 0, 0, 1, 0, dtheta;
+            // y - derivatibe RB 1
+            dtheta = vertices(i, 0) * cos(vel_1(2))
+                - vertices(i, 1) * sin(vel_1(2));
+            expected.row(8 + i) << 0, 1, dtheta, 0, 0, 0;
+            // y - derivative RB 1
+            dtheta = vertices(i, 0) * cos(vel_2(2))
+                - vertices(i, 1) * sin(vel_2(2));
+            expected.row(12 + i) << 0, 0, 0, 0, 1, dtheta;
+        }
+    }
+
+    using namespace ccd::physics;
+
+    auto rbs = RigidBodySystem();
+    rbs.add_rigid_body(RigidBody::Centered(vertices, edges, vel_1));
+    rbs.add_rigid_body(RigidBody::Centered(vertices, edges, vel_2));
+    rbs.assemble();
+
+    Eigen::SparseMatrix<double> actual;
+    rbs.compute_displacements_gradient(rbs.velocities, actual);
+    CHECK((expected - actual.toDense()).squaredNorm() < 1E-6);
+
+    //    Eigen::IOFormat HeavyFmt(4, 0, ", ", ";\n", "[", "]", "[", "]");
+    //    std::cout << expected.format(HeavyFmt) << std::endl;
+    //    std::cout << actual.toDense().format(HeavyFmt) << std::endl;
+}
+
+TEST_CASE("Rigid Body System Hessian", "[RB][RB-System][RB-System-hessian]")
+{
+
+    Eigen::MatrixX2d vertices(4, 2);
+    Eigen::MatrixX2i edges(4, 2);
+    Eigen::Vector3d vel_1, vel_2;
+
+    std::array<Eigen::Matrix<double, 6, 6>, 16> expected;
+
+    vertices << -0.5, -0.5, 0.5, -0.5, 0.5, 0.5, -0.5, 0.5;
+    edges << 0, 1, 1, 2, 2, 3, 3, 0;
+
+    SECTION("Translation Case")
+    {
+        vel_1 << 0.5, 0.5, 0.0;
+        vel_2 << 1.0, 1.0, 0.0;
+    }
+    SECTION("90 Deg Rotation Case")
+    {
+        vel_1 << 0.0, 0.0, 0.5 * M_PI;
+        vel_2 << 0.0, 0.0, M_PI;
+    }
+
+    // clang-format off
+        for (size_t i = 0; i < 4; ++i) {
+            // x body 1
+            expected[i].setZero();
+            expected[i](2,2) = - vertices(i,0) * cos(vel_1(2)) + vertices(i,1) * sin(vel_1(2));
+
+            // y body 1
+            expected[8 + i].setZero();
+            expected[8 + i](2,2) = - vertices(i,0) * sin(vel_1(2)) - vertices(i,1) * cos(vel_1(2));
+
+            // x body 2
+            expected[4 + i].setZero();
+            expected[4 + i](5,5) = - vertices(i,0) * cos(vel_2(2)) + vertices(i,1) * sin(vel_2(2));
+
+            // y body 2
+            expected[12 + i].setZero();
+            expected[12 + i](5,5) = - vertices(i,0) * sin(vel_2(2)) - vertices(i,1) * cos(vel_2(2));
+
+        }
+
+    // clang-format on
+
+    using namespace ccd::physics;
+
+    auto rbs = RigidBodySystem();
+    rbs.add_rigid_body(RigidBody::Centered(vertices, edges, vel_1));
+    rbs.add_rigid_body(RigidBody::Centered(vertices, edges, vel_2));
+    rbs.assemble();
+
+    std::vector<Eigen::SparseMatrix<double>> actual;
+    rbs.compute_displacements_hessian(rbs.velocities, actual);
+    REQUIRE(actual.size() == expected.size());
+    for (size_t i = 0; i < actual.size(); ++i) {
+        REQUIRE(expected[i].rows() == actual[i].rows());
+        REQUIRE(expected[i].cols() == actual[i].cols());
+//        std::cout << i << std::endl;
+//        Eigen::IOFormat HeavyFmt(4, 0, ", ", ";\n", "[", "]", "[", "]");
+//        std::cout << expected[i].format(HeavyFmt) << std::endl;
+//        std::cout << actual[i].toDense().format(HeavyFmt) << std::endl;
+        REQUIRE((expected[i] - actual[i].toDense()).squaredNorm() < 1E-6);
+    }
+}


### PR DESCRIPTION
- Added python notebook to get exact derivatives of RB transformation
- Moved rigid body to its own file (out of rigid_body_system)
    - Added tests for RB gradient/hessian comparing with exact solutions
- Added assembly of gradient and hessian on RB-System
    - Added test for RB-System comparing with exact solutions

Added Rigid Body Problem

- Added Rigid Body Problem to opt/
- Implemented Functional, its gradient and hessian
   - tested against finite differences
- Added tensor util to compute the multiplication of (1x2N) * (2N x 3B x 3B) used by the chain rule.